### PR TITLE
Fix WAR archive

### DIFF
--- a/server/pom.xml
+++ b/server/pom.xml
@@ -87,12 +87,6 @@
         <artifactId>maven-war-plugin</artifactId>
         <version>3.3.0</version>
         <configuration>
-          <packagingIncludes>
-            index.html,
-            js/,
-            css/,
-            **/*.html,
-          </packagingIncludes>
           <packagingExcludes>
             node_modules/
           </packagingExcludes>


### PR DESCRIPTION
- A change I made to `pom.xml` in #15 accidentally caused the servlets to not be included in the WAR archive (as a reminder, the WAR archive is a compressed file containing our HTML, CSS, JS, and compiled servlets that the `simple-jetty-main` uses to serve our server).
- This PR undoes that change.