### PR TITLE
Reformat JSON data from backend

### DIFF
--- a/server/src/main/java/com/google/musicanalysis/site/VideoGenreCount.java
+++ b/server/src/main/java/com/google/musicanalysis/site/VideoGenreCount.java
@@ -9,8 +9,4 @@ public class VideoGenreCount {
     this.genre = genre;
     this.count = count;
   }
-
-  public void incCount() {
-    this.count++;
-  }
 }

--- a/server/src/main/java/com/google/musicanalysis/site/VideoGenreCount.java
+++ b/server/src/main/java/com/google/musicanalysis/site/VideoGenreCount.java
@@ -1,0 +1,11 @@
+package com.google.musicanalysis.site;
+
+/** contains number of youtube videos under a music genre */
+public class VideoGenreCount {
+  private final String genre;
+  private final int count;
+  public VideoGenreCount(String genre, int count) {
+    this.genre = genre;
+    this.count = count;
+  }
+}

--- a/server/src/main/java/com/google/musicanalysis/site/VideoGenreCount.java
+++ b/server/src/main/java/com/google/musicanalysis/site/VideoGenreCount.java
@@ -3,10 +3,14 @@ package com.google.musicanalysis.site;
 /** contains number of youtube videos under a music genre */
 public class VideoGenreCount {
   public final String genre;
-  public static int count;
+  public int count;
 
   public VideoGenreCount(String genre, int count) {
     this.genre = genre;
     this.count = count;
+  }
+
+  public void incCount() {
+    this.count++;
   }
 }

--- a/server/src/main/java/com/google/musicanalysis/site/VideoGenreCount.java
+++ b/server/src/main/java/com/google/musicanalysis/site/VideoGenreCount.java
@@ -2,8 +2,9 @@ package com.google.musicanalysis.site;
 
 /** contains number of youtube videos under a music genre */
 public class VideoGenreCount {
-  private final String genre;
-  private final int count;
+  public final String genre;
+  public static int count;
+
   public VideoGenreCount(String genre, int count) {
     this.genre = genre;
     this.count = count;

--- a/server/src/main/java/com/google/musicanalysis/site/YoutubeGenres.java
+++ b/server/src/main/java/com/google/musicanalysis/site/YoutubeGenres.java
@@ -2,6 +2,7 @@ package com.google.musicanalysis.site;
 import java.util.ArrayList;
 import java.util.List;
 
+/** contains final object that YoutubeServlet.java sends to frontend */
 public class YoutubeGenres {
   private final List<VideoGenreCount> data;
   private final int totalLiked;

--- a/server/src/main/java/com/google/musicanalysis/site/YoutubeGenres.java
+++ b/server/src/main/java/com/google/musicanalysis/site/YoutubeGenres.java
@@ -1,0 +1,13 @@
+package com.google.musicanalysis.site;
+import java.util.ArrayList;
+import java.util.List;
+
+public class YoutubeGenres {
+  private final List<VideoGenreCount> data;
+  private final int totalLiked;
+
+  public YoutubeGenres(List<VideoGenreCount> genreCountList, int totalLiked) {
+    this.data = genreCountList;
+    this.totalLiked = totalLiked;
+  }
+}

--- a/server/src/main/java/com/google/musicanalysis/site/YoutubeServlet.java
+++ b/server/src/main/java/com/google/musicanalysis/site/YoutubeServlet.java
@@ -70,7 +70,7 @@ public class YoutubeServlet extends HttpServlet {
         for (VideoGenreCount videoGenre : genreCountList) {
             if (videoGenre.genre.equals(topic)) {
                 containsGenre = true;
-                videoGenre.count++;
+                videoGenre.count = videoGenre.count + 1;
             }
         }
 
@@ -161,12 +161,11 @@ public class YoutubeServlet extends HttpServlet {
 
         List<VideoGenreCount> genreCountList = new ArrayList<>();
         updateMusicCount(youtubeJsonObj, genreCountList);
-        // int totalLiked = getTotalResults(youtubeJsonObj);
-        // genreCountList.put("totalLiked", totalLiked);
+        int totalLiked = getTotalResults(youtubeJsonObj);
+        YoutubeGenres jsonRes = new YoutubeGenres(genreCountList, totalLiked);
 
         Gson gson = new Gson();
         res.setContentType("application/json"); 
-        res.getWriter().println(gson.toJson(genreCountList));
-
+        res.getWriter().println(gson.toJson(jsonRes));
     }
 }

--- a/server/src/main/java/com/google/musicanalysis/site/YoutubeServlet.java
+++ b/server/src/main/java/com/google/musicanalysis/site/YoutubeServlet.java
@@ -19,7 +19,8 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.servlet.http.HttpSession;
 import javax.servlet.annotation.WebServlet;
-import java.util.HashMap;
+import java.util.ArrayList;
+import java.util.List;
 
 /** Servlet handles youtube api call to get genres of liked videos */
 @WebServlet("/api/youtube")
@@ -59,6 +60,24 @@ public class YoutubeServlet extends HttpServlet {
         return youtubeRes.body();
     }
 
+    /**
+     * updates genreCountList with new genre or count
+     * by checking if .genre attribute of VideoGenreCount obj exists
+     * @param topic identifies youtube video music category e.g. Pop music
+     */
+    protected void updateGenre(String topic, List<VideoGenreCount> genreCountList) {
+        Boolean containsGenre = false;
+        for (VideoGenreCount videoGenre : genreCountList) {
+            if (videoGenre.genre.equals(topic)) {
+                containsGenre = true;
+                videoGenre.count++;
+            }
+        }
+
+        if (!containsGenre) {
+            genreCountList.add(new VideoGenreCount(topic, 1));
+        }
+    }
 
     /**
      * checks whether topic is categorized as music
@@ -75,10 +94,10 @@ public class YoutubeServlet extends HttpServlet {
      * parses through youtube liked videos json string,
      * updates hash map to contain frequency count of each music genre
      * @param youtubeResBody json response of youtube liked videos
-     * @param genreCount hash map of frequency count of each music genre
+     * @param genreCountList list of that contains VideoMusicGenre obj (freq count of each music genre)
      * @param numVideos maximum number of videos to retrieve
      */
-    protected void updateMusicCount(JsonObject youtubeJsonObj, HashMap<String, Integer> genreCount) {
+    protected void updateMusicCount(JsonObject youtubeJsonObj, List<VideoGenreCount> genreCountList) {
         JsonArray videos = youtubeJsonObj.getAsJsonArray("items");
 
         for (int i = 0; i < videos.size(); i++) {
@@ -103,8 +122,7 @@ public class YoutubeServlet extends HttpServlet {
                     break;
                 }
 
-                int count = genreCount.containsKey(topic) ? genreCount.get(topic) : 0;
-                genreCount.put(topic, count + 1);
+                updateGenre(topic, genreCountList);
             }
         }
         return;
@@ -141,14 +159,14 @@ public class YoutubeServlet extends HttpServlet {
         String youtubeResBody = getYoutubeRes(API_KEY, accessToken.toString(), numVideos);
         JsonObject youtubeJsonObj = JsonParser.parseString(youtubeResBody).getAsJsonObject();
 
-        var genreCount = new HashMap<String, Integer>();
-        updateMusicCount(youtubeJsonObj, genreCount);
-        int totalLiked = getTotalResults(youtubeJsonObj);
-        genreCount.put("totalLiked", totalLiked);
+        List<VideoGenreCount> genreCountList = new ArrayList<>();
+        updateMusicCount(youtubeJsonObj, genreCountList);
+        // int totalLiked = getTotalResults(youtubeJsonObj);
+        // genreCountList.put("totalLiked", totalLiked);
 
         Gson gson = new Gson();
         res.setContentType("application/json"); 
-        res.getWriter().println(gson.toJson(genreCount));
+        res.getWriter().println(gson.toJson(genreCountList));
 
     }
 }


### PR DESCRIPTION
Reformatted JSON response of the form 
```{"Music":6, "Pop music":2, "Rock music":1, "Country music":1, "Electronic music":1, "totalLiked":6}```

to 

**```{"data":[{"genre":"Music","count":6},{"genre":"Pop music","count":2},{"genre":"Rock music","count":1},{"genre":"Country music","count":1},{"genre":"Electronic music","count":1}],"totalLiked":6}```**

Achieved this by
- adding `YoutubeGenres.java` class. This is the object we send from backend to front end.
- adding `VideoGenreCount.java` class. This is an object of the form `{"genre":"Music","count":6}`

**Why reformat?**
Needs to be in this format to display d3.js bar chart.