### PR TITLE
Fix deploy

### DIFF
--- a/server/pom.xml
+++ b/server/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>com.google.musicanalysis</groupId>
   <artifactId>site</artifactId>
-  <version>1</version>
+  <version>2</version>
   <packaging>war</packaging>
 
   <properties>
@@ -80,7 +80,7 @@
         <version>2.3.0</version>
         <configuration>
           <deploy.projectId>capstone-t99-2020</deploy.projectId>
-          <deploy.version>1</deploy.version>
+          <deploy.version>2</deploy.version>
         </configuration>
       </plugin>
 
@@ -104,7 +104,13 @@
         <version>3.3.0</version>
         <configuration>
           <packagingExcludes>
-            node_modules/
+            node_modules/,
+            package-lock.json,
+            package.json,
+            .eslintrc,
+            .eslintignore,
+            .stylelintrc,
+            .stylelintignore
           </packagingExcludes>
         </configuration>
       </plugin>

--- a/server/src/main/appengine/app.yaml
+++ b/server/src/main/appengine/app.yaml
@@ -3,7 +3,6 @@ entrypoint: 'java -cp "*" com.google.musicanalysis.jettymain.Main site.war'
 env_variables:
   DOMAIN: http://capstone-t99-2020.appspot.com
 handlers:
-- url: /.*
-  static_dir: /client
-  login: optional
-  secure: optional
+ - url: /(.*/?)*
+   script: auto
+   secure: always


### PR DESCRIPTION
- Fix styles for deployed website
  - Before, you could not access any file in any subdirectory (so anything in `/css` or `/js` would just not work)
- Stop deploying config files like `.eslintrc`
- Website now auto-redirects to HTTPS version